### PR TITLE
Add CNAME for german-melee.de

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+german-melee.de


### PR DESCRIPTION
sorgt dafür, dass github das aufrufen der website von `german-melee.de` aus zulässt.